### PR TITLE
Check arguments for paths/URLs to non-existent documents

### DIFF
--- a/wrapper-apis/WindowListener/implementation.js
+++ b/wrapper-apis/WindowListener/implementation.js
@@ -2,6 +2,11 @@
  * This file is provided by the addon-developer-support repository at
  * https://github.com/thundernest/addon-developer-support
  *
+ * Version: 1.21
+ * - print debug messages only if add-ons are installed temporarily from
+ *   the add-on debug page
+ * - add checks to registered windows and scripts, if they actually exists
+ *
  * Version: 1.20
  * - fix long delay before customize window opens
  * - fix non working removal of palette items

--- a/wrapper-apis/WindowListener/implementation.js
+++ b/wrapper-apis/WindowListener/implementation.js
@@ -215,6 +215,11 @@ var WindowListener = class extends ExtensionCommon.ExtensionAPI {
           self.pathToStartupScript = aPath.startsWith("chrome://")
             ? aPath
             : context.extension.rootURI.resolve(aPath);
+
+          if (self.debug && !this.aDocumentExistsAt(self.pathToStartupScript)) {
+            console.error("Attempt to register non-existent startup script: " + self.pathToStartupScript);
+            if (aPath != self.pathToStartupScript) console.log("(user provided script path was: " + aPath + ")" );
+          }          
         },
 
         registerShutdownScript(aPath) {
@@ -224,6 +229,11 @@ var WindowListener = class extends ExtensionCommon.ExtensionAPI {
           self.pathToShutdownScript = aPath.startsWith("chrome://")
             ? aPath
             : context.extension.rootURI.resolve(aPath);
+
+          if (self.debug && !this.aDocumentExistsAt(self.pathToShutdownScript)) {
+            console.error("Attempt to register non-existent shutdown script: " + self.pathToShutdownScript);
+            if (aPath != self.pathToShutdownScript) console.log("(user provided script path was: " + aPath + ")" );
+          }          
         },
 
         async startListening() {

--- a/wrapper-apis/WindowListener/implementation.js
+++ b/wrapper-apis/WindowListener/implementation.js
@@ -109,7 +109,8 @@ var WindowListener = class extends ExtensionCommon.ExtensionAPI {
 
           if (self.debug && !this.aDocumentExistsAt(self.pathToOptionsPage)) {
             console.error("Attempt to register non-existent options page: " + self.pathToOptionsPage);
-             if (optionsUrl != self.pathToOptionsPage) console.log("(user provided options page was: " + optionsUrl + ")");
+            if (optionsUrl != self.pathToOptionsPage) console.log("(user provided options page was: " + optionsUrl + ")");
+            self.pathToOptionsPage = null;
           }          
         },
 
@@ -219,6 +220,7 @@ var WindowListener = class extends ExtensionCommon.ExtensionAPI {
           if (self.debug && !this.aDocumentExistsAt(self.pathToStartupScript)) {
             console.error("Attempt to register non-existent startup script: " + self.pathToStartupScript);
             if (aPath != self.pathToStartupScript) console.log("(user provided script path was: " + aPath + ")" );
+            self.pathToStartupScript = null;
           }          
         },
 
@@ -233,6 +235,7 @@ var WindowListener = class extends ExtensionCommon.ExtensionAPI {
           if (self.debug && !this.aDocumentExistsAt(self.pathToShutdownScript)) {
             console.error("Attempt to register non-existent shutdown script: " + self.pathToShutdownScript);
             if (aPath != self.pathToShutdownScript) console.log("(user provided script path was: " + aPath + ")" );
+            self.pathToShutdownScript = null;
           }          
         },
 

--- a/wrapper-apis/WindowListener/implementation.js
+++ b/wrapper-apis/WindowListener/implementation.js
@@ -83,15 +83,59 @@ var WindowListener = class extends ExtensionCommon.ExtensionAPI {
 
     return {
       WindowListener: {
-
-        registerOptionsPage(optionsUrl) {
-          self.pathToOptionsPage = optionsUrl.startsWith("chrome://")
-            ? optionsUrl
-            : context.extension.rootURI.resolve(optionsUrl);
+/*
+        chromeResourceExists(chromeUriString) {
+          if (!overlay.startsWith("chrome://")) {
+            throw new Error("chromeResourceExists called with non-\"chrome://\" URI string: " + chromeUriString);
+          }
+          try {
+            await this.readChromeFile(overlay);
+          } catch (e) {
+            return false;
+          }
+          return true;
+        },
+*/
+        aDocumentExistsAt(uriString) {
+          console.log("aDocumentExistsAt(\"" + uriString + "\")");
+          try {
+            let uriObject = Services.io.newURI(uriString);
+            let content = Cu.readUTF8URI(uriObject);
+            return true;
+          } catch (e) {
+            console.log("aDocumentExistsAt(\"" + uriString + "\") got exception:\n" + e);
+            return false;
+          }
         },
 
-        registerDefaultPrefs(defaultUrl) {
-          let url = context.extension.rootURI.resolve(defaultUrl);
+        registerOptionsPage(pathToOptionsPage, debug = context.extension.addonData.temporarilyInstalled) {
+           let optionsUrl = pathToOptionsPage.startsWith("chrome://")
+             ? pathToOptionsPage
+              : context.extension.rootURI.resolve(pathToOptionsPage);
+
+          if (debug && !this.aDocumentExistsAt(optionsUrl)) {
+            console.error("Non-existent options page specified: " + optionsUrl + "\n"
+              + "(originally " + pathToOptionsPage + ")" );
+          }
+          else if (debug) { console.log("aDocumentExistsAt() returned true"); }
+
+          self.pathToOptionsPage = pathToOptionsPage;
+        },
+
+        registerDefaultPrefs(pathToDefaultsJs, debug) {
+          if (!debug) { debug = context.extension.addonData.temporarilyInstalled; }
+          console.log("debug is " + debug);
+          let defaultsJsUrl = context.extension.rootURI.resolve(pathToDefaultsJs);
+          if (defaultsJsUrl == null) {
+            console.error("Failed resolving path to default-preference-setting script into a proper URL: " + pathToDefaultsJs);
+          }
+          if (debug && !this.aDocumentExistsAt(defaultsJsUrl)) {
+            console.error("Attempt to register non-existent default prefs script " + defaultsJsUrl + "\n"
+              + "(originally " + pathToDefaultsJs + ")" );
+            return;
+          }
+          else if (debug) { console.log("aDocumentExistsAt() returned true"); }
+
           let prefsObj = {};
           prefsObj.Services = ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
           prefsObj.pref = function(aName, aDefault) {
@@ -110,7 +154,7 @@ var WindowListener = class extends ExtensionCommon.ExtensionAPI {
                 throw new Error("Preference <" + aName + "> has an unsupported type <" + typeof aDefault + ">. Allowed are string, number and boolean.");
             }
           }
-          Services.scriptloader.loadSubScript(url, prefsObj, "UTF-8");
+          Services.scriptloader.loadSubScript(defaultsJsUrl, prefsObj, "UTF-8");
         },
 
         registerChromeUrl(data) {
@@ -151,15 +195,37 @@ var WindowListener = class extends ExtensionCommon.ExtensionAPI {
           self.resourceData = resourceData;
         },
 
-        registerWindow(windowHref, jsFile) {
+        registerWindow(windowHref, jsFile, debug) {
+          if (!debug) { debug = context.extension.addonData.temporarilyInstalled; }
           if (!self.isBackgroundContext)
             throw new Error("The WindowListener API may only be called from the background page.");
 
+          if (debug && !this.aDocumentExistsAt(windowHref)) {
+            console.error("Attempt to register an injector script for non-existent window" + windowHref);
+            return;
+          }
+          else if (debug) { console.log("aDocumentExistsAt() returned true"); }
+
           if (!self.registeredWindows.hasOwnProperty(windowHref)) {
             // path to JS file can either be chrome:// URL or a relative URL
-            let path = jsFile.startsWith("chrome://")
-              ? jsFile
-              : context.extension.rootURI.resolve(jsFile)
+            let path;
+            if (jsFile.startsWith("chrome://")) {
+               path = jsFile;
+            }
+            else {
+              path = context.extension.rootURI.resolve(jsFile);
+              if (path == null) {
+                console.error("Could not resolve a URL for specified injector script path " + windowHref);
+                return;
+              }
+            }
+            if (debug && !this.aDocumentExistsAt(path)) {
+              console.error("Attempt to register a non-existent injector script" + path + "\n"
+                + "(originally " + jsFile + " )\n"
+                + "for window " + windowHref);
+              return;
+            }
+          else if (debug) { console.log("aDocumentExistsAt() returned true"); }
             self.registeredWindows[windowHref] = path;
           } else {
             console.error("Window <" +windowHref + "> has already been registered");

--- a/wrapper-apis/WindowListener/implementation.js
+++ b/wrapper-apis/WindowListener/implementation.js
@@ -90,15 +90,14 @@ var WindowListener = class extends ExtensionCommon.ExtensionAPI {
       WindowListener: {
 
         aDocumentExistsAt(uriString) {
+          console.log("WindowListener API: Checking if document at <" + uriString + "> used in registration actually exits.");
           try {
             let uriObject = Services.io.newURI(uriString);
             let content = Cu.readUTF8URI(uriObject);
           } catch (e) {
-            console.log("WindowListener API: Document at <" + uriString + "> used in registration does NOT seem to exits.");
             Components.utils.reportError(e); 
             return false;
           }
-          console.log("WindowListener API: Document at <" + uriString + "> used in registration seems to exits.");
           return true;
         },
 
@@ -108,7 +107,7 @@ var WindowListener = class extends ExtensionCommon.ExtensionAPI {
             : context.extension.rootURI.resolve(optionsUrl);
 
           if (self.debug && !this.aDocumentExistsAt(self.pathToOptionsPage)) {
-            console.error("Attempt to register non-existent options page: " + self.pathToOptionsPage);
+            console.error("WindowListener API: Attempt to register non-existent options page: " + self.pathToOptionsPage);
             if (optionsUrl != self.pathToOptionsPage) console.log("(user provided options page was: " + optionsUrl + ")");
             self.pathToOptionsPage = null;
           }          
@@ -118,7 +117,7 @@ var WindowListener = class extends ExtensionCommon.ExtensionAPI {
           let url = context.extension.rootURI.resolve(defaultUrl);
 
           if (self.debug && !this.aDocumentExistsAt(url)) {
-            console.error("Attempt to register non-existent default prefs script: " + url);
+            console.error("WindowListener API: Attempt to register non-existent default prefs script: " + url);
             if (url != defaultUrl) console.log("(user provided script path was: " + defaultUrl + ")" );
             return;
           }
@@ -187,7 +186,7 @@ var WindowListener = class extends ExtensionCommon.ExtensionAPI {
             throw new Error("The WindowListener API may only be called from the background page.");
 
           if (self.debug && !this.aDocumentExistsAt(windowHref)) {
-            console.error("Attempt to register an injector script for non-existent window: " + windowHref);
+            console.error("WindowListener API: Attempt to register an injector script for non-existent window: " + windowHref);
             return;
           }
 
@@ -198,14 +197,14 @@ var WindowListener = class extends ExtensionCommon.ExtensionAPI {
               : context.extension.rootURI.resolve(jsFile)
 
             if (self.debug && !this.aDocumentExistsAt(path)) {
-              console.error("Attempt to register a non-existent injector script: " + path + "\n"
+              console.error("WindowListener API: Attempt to register a non-existent injector script: " + path + "\n"
                 + "for window " + windowHref);
               if (path != jsFile) console.log("(user provided script path was: " + jsFile + " )");
               return;
             }
             self.registeredWindows[windowHref] = path;
           } else {
-            console.error("Window <" +windowHref + "> has already been registered");
+            console.error("WindowListener API: Window <" +windowHref + "> has already been registered");
           }
         },
 
@@ -218,7 +217,7 @@ var WindowListener = class extends ExtensionCommon.ExtensionAPI {
             : context.extension.rootURI.resolve(aPath);
 
           if (self.debug && !this.aDocumentExistsAt(self.pathToStartupScript)) {
-            console.error("Attempt to register non-existent startup script: " + self.pathToStartupScript);
+            console.error("WindowListener API: Attempt to register non-existent startup script: " + self.pathToStartupScript);
             if (aPath != self.pathToStartupScript) console.log("(user provided script path was: " + aPath + ")" );
             self.pathToStartupScript = null;
           }          
@@ -233,7 +232,7 @@ var WindowListener = class extends ExtensionCommon.ExtensionAPI {
             : context.extension.rootURI.resolve(aPath);
 
           if (self.debug && !this.aDocumentExistsAt(self.pathToShutdownScript)) {
-            console.error("Attempt to register non-existent shutdown script: " + self.pathToShutdownScript);
+            console.error("WindowListener API: Attempt to register non-existent shutdown script: " + self.pathToShutdownScript);
             if (aPath != self.pathToShutdownScript) console.log("(user provided script path was: " + aPath + ")" );
             self.pathToShutdownScript = null;
           }          
@@ -395,7 +394,7 @@ var WindowListener = class extends ExtensionCommon.ExtensionAPI {
               }
             });
           } else {
-            console.error("Failed to start listening, no windows registered");
+            console.error("WindowListener API: Failed to start listening, no windows registered");
           }
         },
 

--- a/wrapper-apis/WindowListener/schema.json
+++ b/wrapper-apis/WindowListener/schema.json
@@ -10,14 +10,7 @@
             "name": "aPath",
             "type": "string",
             "description": "Relative path to the default file."
-          },
-          {
-            "name": "debug",
-            "type": "boolean",
-            "optional": true,
-            "description": "Indication of whether to ensure the default preferences file exists at its specified location"
           }
-
         ]
       },
       {
@@ -28,12 +21,6 @@
             "name": "aPath",
             "type": "string",
             "description": "Path to the options page, which should be made accessible in the (legacy) Add-On Options menu."
-          },
-          {
-            "name": "debug",
-            "type": "boolean",
-            "optional": true,
-            "description": "Indication of whether to ensure the options page exists at its specified location"
           }
         ]
       },
@@ -74,12 +61,6 @@
             "name": "jsFile",
             "type": "string",
             "description": "Path to the JavaScript file, which should be loaded into the window."
-          },
-          {
-            "name": "debug",
-            "type": "boolean",
-            "optional": true,
-            "description": "Indication of whether to ensure that the window and the JS file actually exist at their specified locations"
           }
         ]
       },

--- a/wrapper-apis/WindowListener/schema.json
+++ b/wrapper-apis/WindowListener/schema.json
@@ -10,7 +10,14 @@
             "name": "aPath",
             "type": "string",
             "description": "Relative path to the default file."
+          },
+          {
+            "name": "debug",
+            "type": "boolean",
+            "optional": true,
+            "description": "Indication of whether to ensure the default preferences file exists at its specified location"
           }
+
         ]
       },
       {
@@ -21,6 +28,12 @@
             "name": "aPath",
             "type": "string",
             "description": "Path to the options page, which should be made accessible in the (legacy) Add-On Options menu."
+          },
+          {
+            "name": "debug",
+            "type": "boolean",
+            "optional": true,
+            "description": "Indication of whether to ensure the options page exists at its specified location"
           }
         ]
       },
@@ -61,6 +74,12 @@
             "name": "jsFile",
             "type": "string",
             "description": "Path to the JavaScript file, which should be loaded into the window."
+          },
+          {
+            "name": "debug",
+            "type": "boolean",
+            "optional": true,
+            "description": "Indication of whether to ensure that the window and the JS file actually exist at their specified locations"
           }
         ]
       },


### PR DESCRIPTION
* Added a function for checking whether a document exists at a specified URI.
* Added a debug parameter to WL functions taking paths, with default value depending on whether or not the add-on was loaded in debug mode
* When the debug parameter is set, using the existence-check on the options page, the defaults script, URIs' of windows to be overlayed and overlay injector URI's.

Caveat: Currently FAILING for paths which are relative to the add-on's directory structure, SUCCEEDING for "chrome://" URLs.