### PR TITLE
Improve Thunderbird version detection

### DIFF
--- a/wrapper-apis/WindowListener/implementation.js
+++ b/wrapper-apis/WindowListener/implementation.js
@@ -2,7 +2,7 @@
  * This file is provided by the addon-developer-support repository at
  * https://github.com/thundernest/addon-developer-support
  *
- * Version: 1.54
+ * Version: 1.55
  *
  * Author: John Bieling (john@thunderbird.net)
  *
@@ -30,6 +30,7 @@ var WindowListener = class extends ExtensionCommon.ExtensionAPI {
     return {
       major: parseInt(parts[0]),
       minor: parseInt(parts[1]),
+      revision: parseInt(parts[2]),
     }
   }
 
@@ -134,7 +135,8 @@ var WindowListener = class extends ExtensionCommon.ExtensionAPI {
           if (card.addon.id == this.extension.id) {
             let optionsMenu = 
               (this.getThunderbirdVersion().major > 78 && this.getThunderbirdVersion().major < 88) ||
-              (this.getThunderbirdVersion().major == 78 && this.getThunderbirdVersion().minor < 10);
+              (this.getThunderbirdVersion().major == 78 && this.getThunderbirdVersion().minor < 10) ||
+              (this.getThunderbirdVersion().major == 78 && this.getThunderbirdVersion().minor == 10 && this.getThunderbirdVersion().revision < 2);
             if (optionsMenu) {
               // Options menu in 78.0-78.10 and 79-87
               let addonOptionsLegacyEntry = card.querySelector(


### PR DESCRIPTION
The point-point-revsion detection is necessary to fix wrench icon button in addon manager for addons used in Thunderbird 78.10.0 and 78.10.1 releases.